### PR TITLE
feat(SEO): Add robots.txt

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -5,6 +5,7 @@ theme = "hello-friend-ng"
 paginate = 10
 author = "Pa1NarK"
 disableMermaid = false
+enableRobotsTXT = true
 
 [minify]
 minifyOutput = true

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /about/
+Disallow: /work/
+Sitemap: https://pixincreate.dev/sitemap.xml


### PR DESCRIPTION
Disable personal information websites from being crawled like `about` and `work` pages.